### PR TITLE
Return arrays/slices on each call

### DIFF
--- a/intersect.go
+++ b/intersect.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 )
 
-// Complexity: O(n^2)
-func Simple(a interface{}, b interface{}) interface{} {
+// Simple has complexity: O(n^2)
+func Simple(a interface{}, b interface{}) []interface{} {
 	set := make([]interface{}, 0)
 	av := reflect.ValueOf(a)
 
@@ -20,8 +20,8 @@ func Simple(a interface{}, b interface{}) interface{} {
 	return set
 }
 
-// Complexity: O(n * log(n)), a needs to be sorted
-func Sorted(a interface{}, b interface{}) interface{} {
+// Sorted has complexity: O(n * log(n)), a needs to be sorted
+func Sorted(a interface{}, b interface{}) []interface{} {
 	set := make([]interface{}, 0)
 	av := reflect.ValueOf(a)
 	bv := reflect.ValueOf(b)
@@ -39,8 +39,8 @@ func Sorted(a interface{}, b interface{}) interface{} {
 	return set
 }
 
-// Complexity: O(n * x) where x is a factor of hash function efficiency (between 1 and 2)
-func Hash(a interface{}, b interface{}) interface{} {
+// Hash has complexity: O(n * x) where x is a factor of hash function efficiency (between 1 and 2)
+func Hash(a interface{}, b interface{}) []interface{} {
 	set := make([]interface{}, 0)
 	hash := make(map[interface{}]bool)
 	av := reflect.ValueOf(a)

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestSimple(t *testing.T) {
 	s := Simple([]int{1}, []int{2})
+	assert.Equal(t, len(s), 0)
 	assert.Equal(t, s, []interface{}{})
 
 	s = Simple([]int{1, 2}, []int{2})
@@ -16,6 +17,7 @@ func TestSimple(t *testing.T) {
 
 func TestSorted(t *testing.T) {
 	s := Sorted([]int{1}, []int{2})
+	assert.Equal(t, len(s), 0)
 	assert.Equal(t, s, []interface{}{})
 
 	s = Sorted([]int{1, 2}, []int{2})
@@ -24,6 +26,7 @@ func TestSorted(t *testing.T) {
 
 func TestHash(t *testing.T) {
 	s := Hash([]int{1}, []int{2})
+	assert.Equal(t, len(s), 0)
 	assert.Equal(t, s, []interface{}{})
 
 	s = Hash([]int{1, 2}, []int{2})


### PR DESCRIPTION
This returns now `[]interface{}` instead of the old `interface{}` so we don't need to make a `intersect.Hash(first, second).([]interface{})` for casting each time we process such returned lists.