### PR TITLE
replace bool to empty struct in Hash and HashGeneric (optimization)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,16 +34,17 @@ Go v1.18 now supports generics which increases performance compared to reflectio
 
 The average time and allocated bytes are more than halved when using generics, and the number of times bytes have to be allocated from the heap are improved significantly.
 
-| **Name**                              	| **Runs** 	| **Average** 	| **Allocated** 	| **Allocations from heap** 	|
-|---------------------------------------	|-----------------:	|--------------------:	|---------------------:	|-------------------------------------------:	|
-| BenchmarkHash/Size_1-_interface-8     	| 4.631.326         	| 248.1 ns/op        	| 80 B/op             	| 5 allocs/op                               	|
-| BenchmarkHash/Size_1-_generics-8      	| 22.551.091        	| 46.19 ns/op        	| 8 B/op              	| 1 allocs/op                               	|
-| BenchmarkHash/Size_10-_interface-8    	| 581.262          	| 2.042 ns/op         	| 547 B/op            	| 24 allocs/op                              	|
-| BenchmarkHash/Size_10-_generics-8     	| 2.043.096         	| 549.6 ns/op        	| 187 B/op            	| 2 allocs/op                               	|
-| BenchmarkHash/Size_100-_interface-8   	| 59.907           	| 18.721 ns/op        	| 7.325 B/op           	| 213 allocs/op                             	|
-| BenchmarkHash/Size_100-_generics-8    	| 126.622          	| 8.221 ns/op         	| 3.359 B/op           	| 19 allocs/op                              	|
-| BenchmarkHash/Size_1000-_interface-8  	| 7.114            	| 22.1721 ns/op       	| 112.405 B/op         	| 2.038 allocs/op                            	|
-| BenchmarkHash/Size_1000-_generics-8   	| 13.345           	| 91.197 ns/op        	| 53.323 B/op          	| 74 allocs/op                              	|
-| BenchmarkHash/Size_10000-_interface-8 	| 523             	| 2.067.330 ns/op      	| 875.731 B/op         	| 20.173 allocs/op                           	|
-| BenchmarkHash/Size_10000-_generics-8  	| 1.264            	| 828.214 ns/op       	| 427.541 B/op         	| 320 allocs/op                             	|
+| **Name**                              	 | **Runs** 	 | **Average** 	 | **Allocated** 	 | **Allocations from heap** 	 |
+|-----------------------------------------|-----------:|--------------:|----------------:|----------------------------:|
+| BenchmarkHash/Size_1-_interface-16      |    5845340 |   202.9 ns/op |         80 B/op |                 5 allocs/op |
+| BenchmarkHash/Size_1-_generics-16       |   29534389 |   39.86 ns/op |          8 B/op |                 1 allocs/op |
+| BenchmarkHash/Size_10-_interface-16     |     800064 |    1438 ns/op |        515 B/op |                24 allocs/op |
+| BenchmarkHash/Size_10-_generics-16      |    2459796 |   482.6 ns/op |        170 B/op |                 2 allocs/op |
+| BenchmarkHash/Size_100-_interface-16    |      81973 |   14782 ns/op |       6907 B/op |               212 allocs/op |
+| BenchmarkHash/Size_100-_generics-16     |     184526 |    6467 ns/op |       3052 B/op |                19 allocs/op |
+| BenchmarkHash/Size_1000-_interface-16   |       7489 |  164909 ns/op |     101369 B/op |              2036 allocs/op |
+| BenchmarkHash/Size_1000-_generics-16    |      16734 |   70601 ns/op |      47743 B/op |                66 allocs/op |
+| BenchmarkHash/Size_10000-_interface-16  |        754 | 1592308 ns/op |     836264 B/op |             20216 allocs/op |
+| BenchmarkHash/Size_10000-_generics-16   |       1802 |  652946 ns/op |     389466 B/op |               255 allocs/op |
+
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,17 +34,17 @@ Go v1.18 now supports generics which increases performance compared to reflectio
 
 The average time and allocated bytes are more than halved when using generics, and the number of times bytes have to be allocated from the heap are improved significantly.
 
-| **Name**                              	 | **Runs** 	 |   **Average** 	 | **Allocated** 	 | **Allocations from heap** 	 |
-|-----------------------------------------|-----------:|----------------:|----------------:|----------------------------:|
-| BenchmarkHash/Size_1-_interface-16      |  5 845 340 |     202.9 ns/op |         80 B/op |                 5 allocs/op |
-| BenchmarkHash/Size_1-_generics-16       | 29 534 389 |     39.86 ns/op |          8 B/op |                 1 allocs/op |
-| BenchmarkHash/Size_10-_interface-16     |    800 064 |     1 438 ns/op |        515 B/op |                24 allocs/op |
-| BenchmarkHash/Size_10-_generics-16      |  2 459 796 |     482.6 ns/op |        170 B/op |                 2 allocs/op |
-| BenchmarkHash/Size_100-_interface-16    |     81 973 |    14 782 ns/op |      6 907 B/op |               212 allocs/op |
-| BenchmarkHash/Size_100-_generics-16     |    184 526 |     6 467 ns/op |      3 052 B/op |                19 allocs/op |
-| BenchmarkHash/Size_1000-_interface-16   |      7 489 |   164 909 ns/op |    101 369 B/op |             2 036 allocs/op |
-| BenchmarkHash/Size_1000-_generics-16    |     16 734 |    70 601 ns/op |     47 743 B/op |                66 allocs/op |
-| BenchmarkHash/Size_10000-_interface-16  |        754 | 1 592 308 ns/op |    836 264 B/op |            20 216 allocs/op |
-| BenchmarkHash/Size_10000-_generics-16   |      1 802 |   652 946 ns/op |    389 466 B/op |               255 allocs/op |
+| **Name**                               |   **Runs** |     **Average** | **Allocated** | **Allocations from heap** |
+|----------------------------------------|-----------:|----------------:|--------------:|--------------------------:|
+| BenchmarkHash/Size_1-_interface-16     |  5 845 340 |     202.9 ns/op |       80 B/op |               5 allocs/op |
+| BenchmarkHash/Size_1-_generics-16      | 29 534 389 |     39.86 ns/op |        8 B/op |               1 allocs/op |
+| BenchmarkHash/Size_10-_interface-16    |    800 064 |     1 438 ns/op |      515 B/op |              24 allocs/op |
+| BenchmarkHash/Size_10-_generics-16     |  2 459 796 |     482.6 ns/op |      170 B/op |               2 allocs/op |
+| BenchmarkHash/Size_100-_interface-16   |     81 973 |    14 782 ns/op |    6 907 B/op |             212 allocs/op |
+| BenchmarkHash/Size_100-_generics-16    |    184 526 |     6 467 ns/op |    3 052 B/op |              19 allocs/op |
+| BenchmarkHash/Size_1000-_interface-16  |      7 489 |   164 909 ns/op |  101 369 B/op |           2 036 allocs/op |
+| BenchmarkHash/Size_1000-_generics-16   |     16 734 |    70 601 ns/op |   47 743 B/op |              66 allocs/op |
+| BenchmarkHash/Size_10000-_interface-16 |        754 | 1 592 308 ns/op |  836 264 B/op |          20 216 allocs/op |
+| BenchmarkHash/Size_10000-_generics-16  |      1 802 |   652 946 ns/op |  389 466 B/op |             255 allocs/op |
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,17 +34,17 @@ Go v1.18 now supports generics which increases performance compared to reflectio
 
 The average time and allocated bytes are more than halved when using generics, and the number of times bytes have to be allocated from the heap are improved significantly.
 
-| **Name**                              	 | **Runs** 	 | **Average** 	 | **Allocated** 	 | **Allocations from heap** 	 |
-|-----------------------------------------|-----------:|--------------:|----------------:|----------------------------:|
-| BenchmarkHash/Size_1-_interface-16      |    5845340 |   202.9 ns/op |         80 B/op |                 5 allocs/op |
-| BenchmarkHash/Size_1-_generics-16       |   29534389 |   39.86 ns/op |          8 B/op |                 1 allocs/op |
-| BenchmarkHash/Size_10-_interface-16     |     800064 |    1438 ns/op |        515 B/op |                24 allocs/op |
-| BenchmarkHash/Size_10-_generics-16      |    2459796 |   482.6 ns/op |        170 B/op |                 2 allocs/op |
-| BenchmarkHash/Size_100-_interface-16    |      81973 |   14782 ns/op |       6907 B/op |               212 allocs/op |
-| BenchmarkHash/Size_100-_generics-16     |     184526 |    6467 ns/op |       3052 B/op |                19 allocs/op |
-| BenchmarkHash/Size_1000-_interface-16   |       7489 |  164909 ns/op |     101369 B/op |              2036 allocs/op |
-| BenchmarkHash/Size_1000-_generics-16    |      16734 |   70601 ns/op |      47743 B/op |                66 allocs/op |
-| BenchmarkHash/Size_10000-_interface-16  |        754 | 1592308 ns/op |     836264 B/op |             20216 allocs/op |
-| BenchmarkHash/Size_10000-_generics-16   |       1802 |  652946 ns/op |     389466 B/op |               255 allocs/op |
+| **Name**                              	 | **Runs** 	 |   **Average** 	 | **Allocated** 	 | **Allocations from heap** 	 |
+|-----------------------------------------|-----------:|----------------:|----------------:|----------------------------:|
+| BenchmarkHash/Size_1-_interface-16      |  5 845 340 |     202.9 ns/op |         80 B/op |                 5 allocs/op |
+| BenchmarkHash/Size_1-_generics-16       | 29 534 389 |     39.86 ns/op |          8 B/op |                 1 allocs/op |
+| BenchmarkHash/Size_10-_interface-16     |    800 064 |     1 438 ns/op |        515 B/op |                24 allocs/op |
+| BenchmarkHash/Size_10-_generics-16      |  2 459 796 |     482.6 ns/op |        170 B/op |                 2 allocs/op |
+| BenchmarkHash/Size_100-_interface-16    |     81 973 |    14 782 ns/op |      6 907 B/op |               212 allocs/op |
+| BenchmarkHash/Size_100-_generics-16     |    184 526 |     6 467 ns/op |      3 052 B/op |                19 allocs/op |
+| BenchmarkHash/Size_1000-_interface-16   |      7 489 |   164 909 ns/op |    101 369 B/op |             2 036 allocs/op |
+| BenchmarkHash/Size_1000-_generics-16    |     16 734 |    70 601 ns/op |     47 743 B/op |                66 allocs/op |
+| BenchmarkHash/Size_10000-_interface-16  |        754 | 1 592 308 ns/op |    836 264 B/op |            20 216 allocs/op |
+| BenchmarkHash/Size_10000-_generics-16   |      1 802 |   652 946 ns/op |    389 466 B/op |               255 allocs/op |
 
 

--- a/intersect.go
+++ b/intersect.go
@@ -37,14 +37,14 @@ func SortedGeneric[T comparable](a []T, b []T) []T {
 // Hash has complexity: O(n * x) where x is a factor of hash function efficiency (between 1 and 2)
 func HashGeneric[T comparable](a []T, b []T) []T {
 	set := make([]T, 0)
-	hash := make(map[T]bool)
+	hash := make(map[T]struct{})
 
 	for _, v := range a {
-		hash[v] = true
+		hash[v] = struct{}{}
 	}
 
 	for _, v := range b {
-		if hash[v] {
+		if _, ok := hash[v]; ok {
 			set = append(set, v)
 		}
 	}
@@ -98,13 +98,13 @@ func Sorted(a interface{}, b interface{}) []interface{} {
 // Deprecated: Use HashGeneric instead. Complexity same as HashGeneric.
 func Hash(a interface{}, b interface{}) []interface{} {
 	set := make([]interface{}, 0)
-	hash := make(map[interface{}]bool)
+	hash := make(map[interface{}]struct{})
 	av := reflect.ValueOf(a)
 	bv := reflect.ValueOf(b)
 
 	for i := 0; i < av.Len(); i++ {
 		el := av.Index(i).Interface()
-		hash[el] = true
+		hash[el] = struct{}{}
 	}
 
 	for i := 0; i < bv.Len(); i++ {


### PR DESCRIPTION
Replace bool to empty struct

goos: windows
goarch: amd64
pkg: github.com/juliangruber/go-intersect/v2
cpu: Intel(R) Core(TM) i9-9900KF CPU @ 3.60GHz

Benchmarks before:

|                  Name                  |  Count   |     ns/op     |    B/op     |    allocs/op    |
|:--------------------------------------:|:--------:|:-------------:|:-----------:|:---------------:|
|   BenchmarkHash/Size_1-_interface-16   | 5579907  |  204.2 ns/op  |   80 B/op   |   5 allocs/op   |
|   BenchmarkHash/Size_1-_generics-16    | 29267649 |  40.54 ns/op  |   8 B/op    |   1 allocs/op   |
|  BenchmarkHash/Size_10-_interface-16   |  857283  |  1467 ns/op   |  547 B/op   |  24 allocs/op   |
|   BenchmarkHash/Size_10-_generics-16   | 2375664  |  502.3 ns/op  |  187 B/op   |   2 allocs/op   |
|  BenchmarkHash/Size_100-_interface-16  |  79863   |  15345 ns/op  |  7326 B/op  |  213 allocs/op  |
|  BenchmarkHash/Size_100-_generics-16   |  180067  |  6603 ns/op   |  3360 B/op  |  19 allocs/op   |
| BenchmarkHash/Size_1000-_interface-16  |   7207   | 168485 ns/op  | 112392 B/op | 2038 allocs/op  |
|  BenchmarkHash/Size_1000-_generics-16  |  16657   |  73364 ns/op  | 53317 B/op  |  73 allocs/op   |
| BenchmarkHash/Size_10000-_interface-16 |   709    | 1644325 ns/op | 875725 B/op | 20173 allocs/op |
| BenchmarkHash/Size_10000-_generics-16  |   1782   | 677752 ns/op  | 427550 B/op |  319 allocs/op  |

Benchmarks after:

|                  Name                  |  Count   |     ns/op     |    B/op     |    allocs/op    |
|:--------------------------------------:|:--------:|:-------------:|:-----------:|:---------------:|
|   BenchmarkHash/Size_1-_interface-16   | 5845340  |  202.9 ns/op  |   80 B/op   |   5 allocs/op   |
|   BenchmarkHash/Size_1-_generics-16    | 29534389 |  39.86 ns/op  |   8 B/op    |   1 allocs/op   |
|  BenchmarkHash/Size_10-_interface-16   |  800064  |  1438 ns/op   |  515 B/op   |  24 allocs/op   |
|   BenchmarkHash/Size_10-_generics-16   | 2459796  |  482.6 ns/op  |  170 B/op   |   2 allocs/op   |
|  BenchmarkHash/Size_100-_interface-16  |  81973   |  14782 ns/op  |  6907 B/op  |  212 allocs/op  |
|  BenchmarkHash/Size_100-_generics-16   |  184526  |  6467 ns/op   |  3052 B/op  |  19 allocs/op   |
| BenchmarkHash/Size_1000-_interface-16  |   7489   | 164909 ns/op  | 101369 B/op | 2036 allocs/op  |
|  BenchmarkHash/Size_1000-_generics-16  |  16734   |  70601 ns/op  | 47743 B/op  |  66 allocs/op   |
| BenchmarkHash/Size_10000-_interface-16 |   754    | 1592308 ns/op | 836264 B/op | 20216 allocs/op |
| BenchmarkHash/Size_10000-_generics-16  |   1802   | 652946 ns/op  | 389466 B/op |  255 allocs/op  |

Bench diffs (%)

|                  Name                  | Count. % | ns/op, %|  B/op, % | allocs/op, % |
|:--------------------------------------:|:-----:|:-----:|:------:|:---------:|
|   BenchmarkHash/Size_1-_interface-16   | 4,75  | -0,63 |   0    |     0     |
|   BenchmarkHash/Size_1-_generics-16    | 0,91  | -1,67 |   0    |     0     |
|  BenchmarkHash/Size_10-_interface-16   | -6,67 | -1,97 | -5,85  |     0     |
|   BenchmarkHash/Size_10-_generics-16   | 3,54  | -3,92 |  -10   |     0     |
|  BenchmarkHash/Size_100-_interface-16  | 2,64  | -3,66 | -5,72  |   -0,46   |
|  BenchmarkHash/Size_100-_generics-16   | 2,47  | -2,05 | -9,16  |     0     |
| BenchmarkHash/Size_1000-_interface-16  | 3,91  | -2,12 | -9,80  |   -0,09   |
|  BenchmarkHash/Size_1000-_generics-16  | 0,46  | -3,76 | -10,45 |   -9,59   |
| BenchmarkHash/Size_10000-_interface-16 | 6,77  | -3,16 | -4,50  |   -0,21   |
| BenchmarkHash/Size_10000-_generics-16  | 1,12  | -3,66 | -8,90  |  -20,06   |

[Fix explanation](https://dave.cheney.net/2014/03/25/the-empty-struct)
