### PR TITLE
Feature/sorted generic v2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,16 +34,34 @@ Go v1.18 now supports generics which increases performance compared to reflectio
 
 The average time and allocated bytes are more than halved when using generics, and the number of times bytes have to be allocated from the heap are improved significantly.
 
-| **Name**                              	| **Runs** 	| **Average** 	| **Allocated** 	| **Allocations from heap** 	|
-|---------------------------------------	|-----------------:	|--------------------:	|---------------------:	|-------------------------------------------:	|
-| BenchmarkHash/Size_1-_interface-8     	| 4.631.326         	| 248.1 ns/op        	| 80 B/op             	| 5 allocs/op                               	|
-| BenchmarkHash/Size_1-_generics-8      	| 22.551.091        	| 46.19 ns/op        	| 8 B/op              	| 1 allocs/op                               	|
-| BenchmarkHash/Size_10-_interface-8    	| 581.262          	| 2.042 ns/op         	| 547 B/op            	| 24 allocs/op                              	|
-| BenchmarkHash/Size_10-_generics-8     	| 2.043.096         	| 549.6 ns/op        	| 187 B/op            	| 2 allocs/op                               	|
-| BenchmarkHash/Size_100-_interface-8   	| 59.907           	| 18.721 ns/op        	| 7.325 B/op           	| 213 allocs/op                             	|
-| BenchmarkHash/Size_100-_generics-8    	| 126.622          	| 8.221 ns/op         	| 3.359 B/op           	| 19 allocs/op                              	|
-| BenchmarkHash/Size_1000-_interface-8  	| 7.114            	| 22.1721 ns/op       	| 112.405 B/op         	| 2.038 allocs/op                            	|
-| BenchmarkHash/Size_1000-_generics-8   	| 13.345           	| 91.197 ns/op        	| 53.323 B/op          	| 74 allocs/op                              	|
-| BenchmarkHash/Size_10000-_interface-8 	| 523             	| 2.067.330 ns/op      	| 875.731 B/op         	| 20.173 allocs/op                           	|
-| BenchmarkHash/Size_10000-_generics-8  	| 1.264            	| 828.214 ns/op       	| 427.541 B/op         	| 320 allocs/op                             	|
+| **Name**                               |   **Runs** |     **Average** | **Allocated** |     **Allocations from heap** |
+|----------------------------------------|-----------:|----------------:|--------------:|------------------------------:|
+| BenchmarkHash/Size_1-_interface-8      |  4.631.326 |     248.1 ns/op |       80 B/op |                   5 allocs/op |
+| BenchmarkHash/Size_1-_generics-8       | 22.551.091 |     46.19 ns/op |        8 B/op |                   1 allocs/op |
+| BenchmarkHash/Size_10-_interface-8     |    581.262 |     2.042 ns/op |      547 B/op |                  24 allocs/op |
+| BenchmarkHash/Size_10-_generics-8      |  2.043.096 |     549.6 ns/op |      187 B/op |                   2 allocs/op |
+| BenchmarkHash/Size_100-_interface-8    |     59.907 |    18.721 ns/op |    7.325 B/op |                 213 allocs/op |
+| BenchmarkHash/Size_100-_generics-8     |    126.622 |     8.221 ns/op |    3.359 B/op |                  19 allocs/op |
+| BenchmarkHash/Size_1000-_interface-8   |      7.114 |   22.1721 ns/op |  112.405 B/op |               2.038 allocs/op |
+| BenchmarkHash/Size_1000-_generics-8    |     13.345 |    91.197 ns/op |   53.323 B/op |                  74 allocs/op |
+| BenchmarkHash/Size_10000-_interface-8  |        523 | 2.067.330 ns/op |  875.731 B/op |              20.173 allocs/op |
+| BenchmarkHash/Size_10000-_generics-8   |      1.264 |   828.214 ns/op |  427.541 B/op |                 320 allocs/op |
 
+## Sorted Generic V2
+
+`SortedGenericV2` function allows increase performance for the few times, but can be unsafe in some cases cause will change order for elements in the left array.
+
+| **Name**                                           |    **Runs** |     **Average** | **Allocated** | **Allocations from heap** |
+|----------------------------------------------------|------------:|----------------:|--------------:|--------------------------:|
+| BenchmarkSortedGeneric/SortedGeneric_-_1-16        |  41 944 108 |     28.25 ns/op |        8 B/op |               1 allocs/op |
+| BenchmarkSortedGeneric/SortedGenericV2_-_1-16      | 199 261 370 |     5.992 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGeneric_-_10-16       |  10 445 590 |     111.6 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGenericV2_-_10-16     |  20 496 318 |     57.31 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGeneric_-_100-16      |     745 248 |     1 624 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGenericV2_-_100-16    |   1 909 890 |     626.2 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGeneric_-_1000-16     |      38 613 |    31 097 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGenericV2_-_1000-16   |     188 733 |     6 367 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGeneric_-_10000-16    |       3 799 |   308 313 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGenericV2_-_10000-16  |       9 190 |   134 617 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGeneric_-_100000-16   |         327 | 3 679 350 ns/op |        0 B/op |               0 allocs/op |
+| BenchmarkSortedGeneric/SortedGenericV2_-_100000-16 |       1 537 |   783 528 ns/op |        0 B/op |               0 allocs/op |

--- a/intersect.go
+++ b/intersect.go
@@ -34,8 +34,54 @@ func SortedGeneric[T comparable](a []T, b []T) []T {
 	return set
 }
 
+type Comparator func(i, j int) bool
+
+// SortedGenericV2 has complexity: O(n) where n is length of the shortest array.
+// Warning: Function will change left array order
+func SortedGenericV2[T comparable](a []T, b []T, leftGreater Comparator) []T {
+	var i, j, k int
+
+	for {
+		if i >= len(a) || j >= len(b) {
+			break
+		}
+		if a[i] == b[j] {
+			a[k], a[i] = a[i], a[k]
+			i++
+			j++
+			k++
+			continue
+		}
+		if leftGreater(i, j) {
+			j++
+			continue
+		}
+		i++
+		continue
+	}
+	return a[:k]
+}
+
 // Hash has complexity: O(n * x) where x is a factor of hash function efficiency (between 1 and 2)
 func HashGeneric[T comparable](a []T, b []T) []T {
+	set := make([]T, 0)
+	hash := make(map[T]bool)
+
+	for _, v := range a {
+		hash[v] = true
+	}
+
+	for _, v := range b {
+		if hash[v] {
+			set = append(set, v)
+		}
+	}
+
+	return set
+}
+
+// Hash has complexity: O(n * x) where x is a factor of hash function efficiency (between 1 and 2)
+func HashGenericBool[T comparable](a []T, b []T) []T {
 	set := make([]T, 0)
 	hash := make(map[T]bool)
 

--- a/intersect.go
+++ b/intersect.go
@@ -36,7 +36,9 @@ func SortedGeneric[T comparable](a []T, b []T) []T {
 
 type Comparator func(i, j int) bool
 
-// SortedGenericV2 has complexity: O(n) where n is length of the shortest array.
+// SortedGenericV2 has complexity: O(n + x) where n is length of the shortest array and x duplicate cases in the longest array.
+// Best case complexity: O(n) where n is length of the shortest array (all values unique)
+// Worst case complexity: O(n) where n is length of the longest array (all values of the longest array are duplicates of intersect match)
 // Warning: Function will change left array order
 func SortedGenericV2[T comparable](a []T, b []T, leftGreater Comparator) []T {
 	var i, j, k int

--- a/intersect.go
+++ b/intersect.go
@@ -82,24 +82,6 @@ func HashGeneric[T comparable](a []T, b []T) []T {
 	return set
 }
 
-// Hash has complexity: O(n * x) where x is a factor of hash function efficiency (between 1 and 2)
-func HashGenericBool[T comparable](a []T, b []T) []T {
-	set := make([]T, 0)
-	hash := make(map[T]bool)
-
-	for _, v := range a {
-		hash[v] = true
-	}
-
-	for _, v := range b {
-		if hash[v] {
-			set = append(set, v)
-		}
-	}
-
-	return set
-}
-
 func containsGeneric[T comparable](b []T, e T) bool {
 	for _, v := range b {
 		if v == e {

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/bmizerany/assert"
@@ -63,6 +64,39 @@ func TestHash(t *testing.T) {
 	assert.Equal(t, s, []interface{}{2})
 }
 
+func TestSortedGenericV2(t *testing.T) {
+	a := []int{1}
+	b := []int{2}
+	s := SortedGenericV2(a, b, func(i, j int) bool { return a[i] > b[j] })
+	assert.Equal(t, len(s), 0)
+	assert.Equal(t, s, []int{})
+	a = []int{1, 2}
+	b = []int{2}
+	s = SortedGenericV2(a, b, func(i, j int) bool { return a[i] > b[j] })
+	assert.Equal(t, s, []int{2})
+	assert.Equal(t, a, []int{2, 1})
+}
+
+var blackholeSortedGenericV2 []int
+var blackholeSortedGeneric []int
+
+func BenchmarkSortedGeneric(b *testing.B) {
+	for _, v := range []int{1, 10, 100, 1_000, 10_000, 100_000} {
+		sortedArr1 := createSortedRandomSlice(v)
+		sortedArr2 := createSortedRandomSlice(v)
+		b.Run(fmt.Sprintf("SortedGenericV2 - %d", v), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				blackholeSortedGenericV2 = SortedGenericV2(sortedArr1, sortedArr2, func(i, j int) bool { return sortedArr1[i] > sortedArr2[j] })
+			}
+		})
+		b.Run(fmt.Sprintf("SortedGeneric - %d", v), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				blackholeSortedGeneric = SortedGeneric(sortedArr1, sortedArr2)
+			}
+		})
+	}
+}
+
 var blackholeHashGeneric []int
 var blackholeHash []interface{}
 
@@ -88,5 +122,11 @@ func createRandomSlice(size int) []int {
 	for i := 0; i < size; i++ {
 		slice[i] = rand.Intn(int(math.Pow(float64(size), 2)))
 	}
+	return slice
+}
+
+func createSortedRandomSlice(size int) []int {
+	slice := createRandomSlice(size)
+	sort.Slice(slice, func(i, j int) bool { return slice[i] < slice[j] })
 	return slice
 }


### PR DESCRIPTION
Hello!  

I have some feature proposal, that can increase perforamance for sorted array case for few times.

Idea is about changing places for elements of the left array and iterating on both arrays at the same time, we can win a lot of perforamnce cause it makes complexity O(n + x) where n is length of the shortest array and x duplicate cases in the longest array. 

n+x always less or equal length of the longest array.
 
It can be unsafe in case when its important to save order of input. Also it will find duplate matches only for the shortest array too.

Usage example:
```go
	a = []int{1, 2}
	b = []int{2}
	s = SortedGenericV2(a, b, func(i, j int) bool { return a[i] > b[j] })
```
Output:
```
[2]
```

New a's order:
```
[2, 1]
```

vanila function benchmarks:

| **Name**                                           |    **Runs** |     **Average** | **Allocated** | **Allocations from heap** |
|----------------------------------------------------|------------:|----------------:|--------------:|--------------------------:|
| BenchmarkSortedGeneric/SortedGeneric_-_1-16        |  41 944 108 |     28.25 ns/op |        8 B/op |               1 allocs/op |
| BenchmarkSortedGeneric/SortedGeneric_-_10-16       |  10 445 590 |     111.6 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGeneric_-_100-16      |     745 248 |     1 624 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGeneric_-_1000-16     |      38 613 |    31 097 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGeneric_-_10000-16    |       3 799 |   308 313 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGeneric_-_100000-16   |         327 | 3 679 350 ns/op |        0 B/op |               0 allocs/op |

proposal benchmarks:

| **Name**                                           |    **Runs** |     **Average** | **Allocated** | **Allocations from heap** |
|----------------------------------------------------|------------:|----------------:|--------------:|--------------------------:|
| BenchmarkSortedGeneric/SortedGenericV2_-_1-16      | 199 261 370 |     5.992 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGenericV2_-_10-16     |  20 496 318 |     57.31 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGenericV2_-_100-16    |   1 909 890 |     626.2 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGenericV2_-_1000-16   |     188 733 |     6 367 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGenericV2_-_10000-16  |       9 190 |   134 617 ns/op |        0 B/op |               0 allocs/op |
| BenchmarkSortedGeneric/SortedGenericV2_-_100000-16 |       1 537 |   783 528 ns/op |        0 B/op |               0 allocs/op |

speed diffs:

| **size**  | **Average diff, ns/op** | **Average diff, %** |
|:----------|------------------------:|--------------------:|
| 1         |           -22,258 ns/op |             -78,78% |
| 10        |            -54,29 ns/op |             -48,64% |
| 100       |            -997,8 ns/op |             -61,45% |
| 1 000     |           -24 730 ns/op |             -99,97% |
| 10 000    |          -173 696 ns/op |             -56,33% |
| 100 000   |        -2 895 822 ns/op |             -78,70% |

As you see, with a little risks (like losing order of input array and weird behaviour for a lot of duplicate matches) you can get a huge performance boost.

P.S. alogorythm idea is not mine, my collegue (@painkuter) shared it with me.

